### PR TITLE
181467509 create permissions

### DIFF
--- a/app/controllers/dynamic_pages_controller.rb
+++ b/app/controllers/dynamic_pages_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class DynamicPagesController < ApplicationController
+  before_action :require_admin
   def index
     @all_dynamic_pages = DynamicPage.all
   end

--- a/app/controllers/dynamic_pages_controller.rb
+++ b/app/controllers/dynamic_pages_controller.rb
@@ -45,6 +45,8 @@ class DynamicPagesController < ApplicationController
       params.require(:dynamic_page).require(:slug)
       params.require(:dynamic_page).require(:title)
       params.require(:dynamic_page).require(:permissions)
+      params.require(:dynamic_page).require(:creator_id)
+      params.require(:dynamic_page).require(:last_editor)
       params.require(:dynamic_page).permit(:slug, :body, :title, :permissions, :creator_id, :last_editor)
     end
 end

--- a/app/controllers/dynamic_pages_controller.rb
+++ b/app/controllers/dynamic_pages_controller.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
 class DynamicPagesController < ApplicationController
-  before_action :require_admin
+  before_action :require_admin, except: [:index, :show]
   def index
     @all_dynamic_pages = DynamicPage.all
   end
   def delete
-    if !is_admin?
-      redirect_to dynamic_pages_path, alert: "Only administrators can delete!"
-    else
-      DynamicPage.destroy(params[:id])
-      redirect_to dynamic_pages_path
-    end
+    DynamicPage.destroy(params[:id])
+    redirect_to dynamic_pages_path
   end
   def new
     @dynamic_page = DynamicPage.new

--- a/app/controllers/dynamic_pages_controller.rb
+++ b/app/controllers/dynamic_pages_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class DynamicPagesController < ApplicationController
-  before_action :require_admin
   def index
     @all_dynamic_pages = DynamicPage.all
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,8 +19,7 @@ module ApplicationHelper
       "New School": new_school_path,
       "All Schools": schools_path,
       "All Teachers": teachers_path,
-      "Email Templates": email_templates_path,
-      "Pages": dynamic_pages_path
+      "Email Templates": email_templates_path
     }
   end
 end

--- a/app/views/dynamic_pages/index.html.erb
+++ b/app/views/dynamic_pages/index.html.erb
@@ -11,8 +11,10 @@
     <th scope="col">Slug</th>
     <th scope="col">Last Editor</th>
     <th scope="col">Created At</th>
-    <th scope="col">Edit</th>
-    <th scope="col">Delete</th>
+    <% if session[:user_id] && Teacher.find(session[:user_id]).admin %>
+      <th scope="col">Edit</th>
+      <th scope="col">Delete</th>
+    <% end %>
     </tr>
   </thead>
   <tbody>
@@ -23,7 +25,7 @@
           <td> <%= p.slug %> </td>
           <td> <%= Teacher.find(p.last_editor).full_name %> </td>
           <td> <%= p.created_at %> </td>
-          <% if session[:user_id]%>
+          <% if session[:user_id] && Teacher.find(session[:user_id]).admin %>
             <td> <%= button_to("Edit", {action: "edit", slug: p.slug}, class: "btn btn-primary", type: 'button', id: "edit_"+p.slug) %> </td>
             <td> <%= button_to("Delete", {action: "delete", id: p.id}, class: "btn btn-danger", type: 'button', id: "delete_"+p.slug) %> </td>
           <% end %>
@@ -34,8 +36,10 @@
           <td> <%= p.slug %> </td>
           <td> <%= Teacher.find(p.last_editor).full_name %> </td>
           <td> <%= p.created_at %> </td>
-          <td> <%= button_to("Edit", {action: "edit", slug: p.slug}, class: "btn btn-primary", type: 'button', id: "edit_"+p.slug) %> </td>
-          <td> <%= button_to("Delete", {action: "delete", id: p.id}, class: "btn btn-danger", type: 'button', id: "delete_"+p.slug) %> </td>
+          <% if Teacher.find(session[:user_id]).admin %>
+            <td> <%= button_to("Edit", {action: "edit", slug: p.slug}, class: "btn btn-primary", type: 'button', id: "edit_"+p.slug) %> </td>
+            <td> <%= button_to("Delete", {action: "delete", id: p.id}, class: "btn btn-danger", type: 'button', id: "delete_"+p.slug) %> </td>
+          <% end %>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/dynamic_pages/index.html.erb
+++ b/app/views/dynamic_pages/index.html.erb
@@ -5,7 +5,7 @@
     </div>
 
     <div class="col-3">
-      <% if Teacher.find(session[:user_id]).admin %>
+      <% if session[:user_id] && Teacher.find(session[:user_id]).admin %>
         <%= button_to("New Page", {action: "new"}, method: "get", class: "btn btn-primary btn-lg", type: 'button') %>
       <% end %>
     </div>

--- a/app/views/dynamic_pages/index.html.erb
+++ b/app/views/dynamic_pages/index.html.erb
@@ -17,7 +17,18 @@
   </thead>
   <tbody>
     <% @all_dynamic_pages.each do |p| %>
-      <% if p.permissions ==  "Admin" || Teacher.find(session[:user_id]).admin %>
+      <% if p.permissions == "Public" %>
+        <tr align = "center">
+          <td> <%= link_to(p.title, controller: "dynamic_pages", action: "show", slug: p.slug) %> </td>
+          <td> <%= p.slug %> </td>
+          <td> <%= Teacher.find(p.last_editor).full_name %> </td>
+          <td> <%= p.created_at %> </td>
+          <% if session[:user_id]%>
+            <td> <%= button_to("Edit", {action: "edit", slug: p.slug}, class: "btn btn-primary", type: 'button', id: "edit_"+p.slug) %> </td>
+            <td> <%= button_to("Delete", {action: "delete", id: p.id}, class: "btn btn-danger", type: 'button', id: "delete_"+p.slug) %> </td>
+          <% end %>
+        </tr>
+      <% elsif session[:user_id] && (Teacher.find(session[:user_id]).admin || p.permissions != "Admin") %>
         <tr align = "center">
           <td> <%= link_to(p.title, controller: "dynamic_pages", action: "show", slug: p.slug) %> </td>
           <td> <%= p.slug %> </td>

--- a/app/views/layouts/_navbar.erb
+++ b/app/views/layouts/_navbar.erb
@@ -12,6 +12,9 @@
           </li>
         <% end %>
       <% end %>
+      <li class='nav-item'>
+        <%= link_to "Pages", dynamic_pages_path, class: "nav-link" %>
+      </li>
       <% if current_user %>
         <li class='nav-item'>
           <a class='nav-link' href='/logout' data-method='delete'>Logout</a>

--- a/features/dynamic_pages_admin.feature
+++ b/features/dynamic_pages_admin.feature
@@ -1,4 +1,4 @@
-Feature: dynamic pages features
+Feature: dynamic pages features as an admin
 
     As an admin, I should be able to create, view, and edit dynamic pages
 

--- a/features/dynamic_pages_permissions.feature
+++ b/features/dynamic_pages_permissions.feature
@@ -19,27 +19,31 @@ Scenario: Admins can see everything
     Given I have an admin email
     And I follow "Log In"
     Then I can log in with Google
-    Given I follow "Pages"
+    Then I follow "Pages"
     Then I should be on the dynamic pages index
     And I should see "Test Public Page"
     And I should see "Test Teacher Page"
     And I should see "Test Admin Page"
     And I should see "Edit"
     And I should see "Delete"
-    And I should see "New Page"
+    And I should see a button named "Delete"
+    And I should see a button named "Edit"
+    And I should see a button named "New Page"
 
-Scenario: Teachers can't see admin pages or new page button
+Scenario: Teachers can't see admin pages, edit/delete button, or new page button
     Given I am on the BJC home page
     Given I have a teacher Google email
     And I follow "Log In"
     Then I can log in with Google
-    Given I follow "Pages"
+    Then I follow "Pages"
     Then I should be on the dynamic pages index
     And I should see "Test Public Page"
     And I should see "Test Teacher Page"
     And I should not see "Test Admin Page"
     And I should not see "Delete"
-    And I should not see "New Page"
+    And I should not see a button named "Delete"
+    And I should not see a button named "Edit"
+    And I should not see a button named "New Page"
 
 Scenario: Public can only see public pages
     Given I am on the BJC home page
@@ -49,4 +53,63 @@ Scenario: Public can only see public pages
     And I should not see "Test Teacher Page"
     And I should not see "Test Admin Page"
     And I should not see "Delete"
-    And I should not see "New Page"
+    And I should not see a button named "Delete"
+    And I should not see a button named "Edit"
+    And I should not see a button named "New Page"
+
+Scenario: Admin can access all pages
+    Given I am on the BJC home page
+    Given I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    Then I follow "Pages"
+    Then I should be on the dynamic pages index
+    And I follow "Test Public Page"
+    Then I should be on the dynamic page for slug "test_slug_public"
+    And I should see "Test Public Page"
+    And I should see "Test public body."
+    Then I follow "Pages"
+    Then I should be on the dynamic pages index
+    And I follow "Test Teacher Page"
+    Then I should be on the dynamic page for slug "test_slug_verified_teacher"
+    And I should see "Test Teacher Page"
+    And I should see "Test teacher body."
+    Then I follow "Pages"
+    Then I should be on the dynamic pages index
+    And I follow "Test Admin Page"
+    Then I should be on the dynamic page for slug "test_slug_admin"
+    And I should see "Test Admin Page"
+    And I should see "Test admin body."
+
+Scenario: Teachers can access public pages
+    Given I am on the BJC home page
+    Given I have a teacher Google email
+    And I follow "Log In"
+    Then I can log in with Google
+    Then I follow "Pages"
+    Then I should be on the dynamic pages index
+    And I follow "Test Public Page"
+    Then I should be on the dynamic page for slug "test_slug_public"
+    And I should see "Test Public Page"
+    And I should see "Test public body."
+
+Scenario: Teachers can access teacher pages
+    Given I am on the BJC home page
+    Given I have a teacher Google email
+    And I follow "Log In"
+    Then I can log in with Google
+    Then I follow "Pages"
+    Then I should be on the dynamic pages index
+    And I follow "Test Teacher Page"
+    Then I should be on the dynamic page for slug "test_slug_verified_teacher"
+    And I should see "Test Teacher Page"
+    And I should see "Test teacher body."
+
+Scenario: Public can access public pages
+    Given I am on the BJC home page
+    Then I follow "Pages"
+    Then I should be on the dynamic pages index
+    And I follow "Test Public Page"
+    Then I should be on the dynamic page for slug "test_slug_public"
+    And I should see "Test Public Page"
+    And I should see "Test public body."

--- a/features/dynamic_pages_permissions.feature
+++ b/features/dynamic_pages_permissions.feature
@@ -1,0 +1,52 @@
+Feature: dynamic pages features a verified teacher
+
+    As a verifed teacher, I should only be able to see pages I have access to
+
+Background: Has admin and teacher in DB along with pages of each permission type
+    Given I seed data
+    Given the following teachers exist:
+    | first_name | last_name | admin | email                        |
+    | Joseph     | Mamoa     | true  | testadminuser@berkeley.edu   |
+    | Todd       | Teacher   | false | testteacher@berkeley.edu     |
+    Given the following dynamic pages exist:
+    | slug | title | body | permissions                        |
+    | test_slug_admin            | Test Admin Page   | Test admin body.   | Admin   |
+    | test_slug_verified_teacher | Test Teacher Page | Test teacher body. | Verified Teacher |
+    | test_slug_public           | Test Public Page  | Test public body.  | Public   |
+
+Scenario: Admins can see everything
+    Given I am on the BJC home page
+    Given I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    Given I follow "Pages"
+    Then I should be on the dynamic pages index
+    And I should see "Test Public Page"
+    And I should see "Test Teacher Page"
+    And I should see "Test Admin Page"
+    And I should see "Edit"
+    And I should see "Delete"
+    And I should see "New Page"
+
+Scenario: Teachers can't see admin pages or new page button
+    Given I am on the BJC home page
+    Given I have a teacher Google email
+    And I follow "Log In"
+    Then I can log in with Google
+    Given I follow "Pages"
+    Then I should be on the dynamic pages index
+    And I should see "Test Public Page"
+    And I should see "Test Teacher Page"
+    And I should not see "Test Admin Page"
+    And I should not see "Delete"
+    And I should not see "New Page"
+
+Scenario: Public can only see public pages
+    Given I am on the BJC home page
+    Given I follow "Pages"
+    Then I should be on the dynamic pages index
+    And I should see "Test Public Page"
+    And I should not see "Test Teacher Page"
+    And I should not see "Test Admin Page"
+    And I should not see "Delete"
+    And I should not see "New Page"

--- a/features/step_definitions/dynamic_page_steps.rb
+++ b/features/step_definitions/dynamic_page_steps.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+Given(/the following dynamic pages exist/) do |dynamic_pages_table|
+  dynamic_pages_default = {
+    slug: "test_slug",
+    title: "Test Page Title",
+    body: "Test page body.",
+    permissions: "Public",
+    creator_id: Teacher.all[0].id,
+    last_editor: Teacher.all[0].id
+  }
+  dynamic_pages_table.symbolic_hashes.each do |dynamic_page|
+    dynamic_pages_default.each do |key, value|
+      dynamic_page[key] = value if dynamic_page[key].nil?
+    end
+    DynamicPage.create!(dynamic_page)
+  end
+end
+
 When(/^(?:|I )fill in the dynamic_page_body with "([^"]*)"$/) do |value|
   find("trix-editor").click.set(value)
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -265,6 +265,10 @@ Then(/^(?:|I )should see a button named "([^"]*)"$/) do |text|
   expect(page).to have_button(text)
 end
 
+Then(/^(?:|I )should not see a button named "([^"]*)"$/) do |text|
+  expect(page).to have_no_button(text)
+end
+
 Given(/I seed data/) do
   Rails.application.load_seed
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -29,6 +29,7 @@ module NavigationHelpers
     when /^the dynamic pages index$/ then dynamic_pages_path
     when /^the new dynamic pages page$/ then "/dynamic_pages/new"
     when /^the edit dynamic pages page for (.*)$/ then "/pages/edit/" + $1[1..-2]
+    when /^the dynamic page for slug (.*)$/ then "/pages/" + $1[1..-2]
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:
     #

--- a/spec/controllers/dynamic_pages_controller_spec.rb
+++ b/spec/controllers/dynamic_pages_controller_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe DynamicPagesController, type: :controller do
   end
 
   it "requires slug to create" do
+    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
     expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    post :create, {
+    expect { post :create, {
         params: {
           dynamic_page: {
             title: @dynamic_page_title,
@@ -61,13 +62,15 @@ RSpec.describe DynamicPagesController, type: :controller do
             last_editor: 0
           }
         }
-    }
+      }
+    }.to raise_error(ActionController::ParameterMissing)
     expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
   end
 
   it "requires title to create" do
+    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
     expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    post :create, {
+    expect { post :create, {
         params: {
           dynamic_page: {
             slug: @dynamic_page_slug,
@@ -77,13 +80,15 @@ RSpec.describe DynamicPagesController, type: :controller do
             last_editor: 0
           }
         }
-    }
+      }
+    }.to raise_error(ActionController::ParameterMissing)
     expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
   end
 
   it "requires permissions to create" do
+    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
     expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    post :create, {
+    expect { post :create, {
         params: {
           dynamic_page: {
             title: @dynamic_page_title,
@@ -93,7 +98,44 @@ RSpec.describe DynamicPagesController, type: :controller do
             last_editor: 0
           }
         }
-    }
+      }
+    }.to raise_error(ActionController::ParameterMissing)
+    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+  end
+
+  it "requires creator_id to create" do
+    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+    expect { post :create, {
+        params: {
+          dynamic_page: {
+            title: @dynamic_page_title,
+            slug: @dynamic_page_slug,
+            body: "<p>Test page body.</p>",
+            permissions: "Admin",
+            last_editor: 0
+          }
+        }
+      }
+    }.to raise_error(ActionController::ParameterMissing)
+    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+  end
+
+  it "requires last_editor to create" do
+    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+    expect { post :create, {
+        params: {
+          dynamic_page: {
+            title: @dynamic_page_title,
+            slug: @dynamic_page_slug,
+            body: "<p>Test page body.</p>",
+            permissions: "Admin",
+            last_editor: 0
+          }
+        }
+      }
+    }.to raise_error(ActionController::ParameterMissing)
     expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
   end
 


### PR DESCRIPTION
The teachers and public now have access to the dynamic_pages#index page. They can navigate to different pages depending on their status (verified-teacher or not) and the permissions specified by each individual page. Admins can still view all pages and admins are the only ones that can create, edit, and delete pages.