### PR TITLE
181566375 redirect to to render when slug taken

### DIFF
--- a/app/controllers/dynamic_pages_controller.rb
+++ b/app/controllers/dynamic_pages_controller.rb
@@ -14,11 +14,12 @@ class DynamicPagesController < ApplicationController
     end
   end
   def new
-    @dynamic_page = DynamicPage.new
+    @dynamic_page = DynamicPage.new(flash[:dynamic_page])
   end
   def create
     @dynamic_page = DynamicPage.new(dynamic_page_params)
     if DynamicPage.find_by(slug: @dynamic_page.slug)
+      flash[:dynamic_page] = params[:dynamic_page]
       redirect_to({ action: "new" }, alert:  "That slug already exists :(")
     elsif @dynamic_page.save
       flash[:success] = "Created #{@dynamic_page.title} page successfully."
@@ -38,12 +39,10 @@ class DynamicPagesController < ApplicationController
     temp_slug = @dynamic_page.slug
     @dynamic_page.assign_attributes(dynamic_page_params)
     if temp_slug == @dynamic_page.slug
-      # redirect_to({ action: "edit", slug: temp_slug }, alert:  "That slug already exists :(")
       @dynamic_page.save
       redirect_to dynamic_pages_path
     elsif not DynamicPage.find_by(slug: @dynamic_page.slug) # nil?
       flash[:success] = "Updated #{@dynamic_page.title} page successfully."
-      # redirect_to ({ action: "show", slug: @dynamic_page.slug })
       @dynamic_page.save
       redirect_to dynamic_pages_path
     elsif DynamicPage.find_by(slug: @dynamic_page.slug) # not nil?

--- a/app/controllers/dynamic_pages_controller.rb
+++ b/app/controllers/dynamic_pages_controller.rb
@@ -35,9 +35,23 @@ class DynamicPagesController < ApplicationController
   end
   def update
     @dynamic_page ||= DynamicPage.find(params[:id])
+    temp_slug = @dynamic_page.slug
     @dynamic_page.assign_attributes(dynamic_page_params)
-    @dynamic_page.save
-    redirect_to dynamic_pages_path
+    if temp_slug == @dynamic_page.slug
+      # redirect_to({ action: "edit", slug: temp_slug }, alert:  "That slug already exists :(")
+      @dynamic_page.save
+      redirect_to dynamic_pages_path
+    elsif not DynamicPage.find_by(slug: @dynamic_page.slug) # nil?
+      flash[:success] = "Updated #{@dynamic_page.title} page successfully."
+      # redirect_to ({ action: "show", slug: @dynamic_page.slug })
+      @dynamic_page.save
+      redirect_to dynamic_pages_path
+    elsif DynamicPage.find_by(slug: @dynamic_page.slug) # not nil?
+      redirect_to({ action: "edit", slug: temp_slug }, alert:  "That slug already exists :(")
+    else
+      redirect_to root_path, alert: "Failed to submit information :("
+    end
+
   end
 
   private

--- a/app/views/dynamic_pages/index.html.erb
+++ b/app/views/dynamic_pages/index.html.erb
@@ -24,7 +24,7 @@
           <td> <%= p.slug %> </td>
           <td> <%= Teacher.find(p.last_editor).full_name %> </td>
           <td> <%= p.created_at %> </td>
-          <td> <%= button_to("Edit", {action: "edit", slug: p.slug}, class: "btn btn-primary", type: 'button', id: "edit_"+p.slug) %> </td>
+          <td> <%= button_to("Edit", {action: "edit", slug: p.slug}, method: :get, class: "btn btn-primary", type: 'button', id: "edit_"+p.slug) %> </td>
           <td> <%= button_to("Delete", {action: "delete", id: p.id}, class: "btn btn-danger", type: 'button', id: "delete_"+p.slug) %> </td>
         </tr>
       <% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,8 +1,10 @@
 <% flash.each do |name, msg| %>
-  <div class="alert alert-<%=alert_class(name) %> alert-dismissible" role="alert">
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-        <span aria-hidden="true">&times;</span>
-    </button>
-    <%= msg %>
-  </div>
+  <% if not ["dynamic_page"].include? name %>
+    <div class="alert alert-<%=alert_class(name) %> alert-dismissible" role="alert">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+      </button>
+      <%= msg %>
+    </div>
+  <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,13 +29,12 @@ Rails.application.routes.draw do
 
   get "/dashboard", to: "main#dashboard", as: "dashboard"
 
-  resources :dynamic_pages do
+  resources :dynamic_pages, except: [:edit] do
     member do
       post :delete
-      get :new
     end
   end
 
   get "pages/:slug", to: "dynamic_pages#show"
-  post "pages/edit/:slug", to: "dynamic_pages#edit"
+  get "pages/edit/:slug", to: "dynamic_pages#edit"
 end

--- a/features/dynamic_pages_admin.feature
+++ b/features/dynamic_pages_admin.feature
@@ -86,7 +86,7 @@ Scenario: Can create a new page with the same title as a page that already exist
     And I press "Submit"
     Then I should see "Test Title"
 
-Scenario: (Prob need to edit this later) Can't create a page with a slug that already exists
+Scenario: Can't create a page with a slug that already exists
     Given I am on the new dynamic pages page
     And I fill in "dynamic_page_title" with "Test Title"
     And I fill in "dynamic_page_slug" with "test_slug"
@@ -99,6 +99,26 @@ Scenario: (Prob need to edit this later) Can't create a page with a slug that al
     And I choose "inlineRadioAdmin"
     And I press "Submit"
     Then I should be on the new dynamic pages page
+
+Scenario: Attempting to create page with taken slug doesn't delete form input
+    Given I am on the new dynamic pages page
+    And I fill in "dynamic_page_title" with "Test Title"
+    And I fill in "dynamic_page_slug" with "test_slug"
+    And I fill in the dynamic_page_body with "Don't see this"
+    And I choose "inlineRadioAdmin"
+    And I press "Submit"
+    And I follow "Pages"
+    And I press "New Page"
+    And I fill in "dynamic_page_title" with "Test Title"
+    And I fill in "dynamic_page_slug" with "test_slug"
+    And I fill in the dynamic_page_body with "This is a test"
+    And I choose "inlineRadioAdmin"
+    And I press "Submit"
+    Then I should be on the new dynamic pages page
+    And the "dynamic_page_title" field should contain "Test Title"
+    And the "dynamic_page_slug" field should contain "test_slug"
+    And I should see "This is a test"
+    And I should not see "Don't see this"
 
 Scenario: I can delete pages
     Given I am on the new dynamic pages page
@@ -153,3 +173,53 @@ Scenario: Can edit pages with correct prefilled content in the form.
     And the "dynamic_page_title" field should contain "Test Title"
     And the "dynamic_page_slug" field should contain "test_slug"
     And I should see "This is a test"
+    Then I fill in "dynamic_page_title" with "New Title"
+    And I fill in "dynamic_page_slug" with "new_slug"
+    And I choose "inlineRadioPublic"
+    And I fill in the dynamic_page_body with "This is a test 2"
+    And I press "Update"
+    Then I should see "New Title"
+    And I should see "new_slug"
+    Then I should be on the dynamic pages index
+    And I should not see "Test Title"
+    And I should not see "test_slug"
+
+Scenario: Can update page even if no changes
+    Given I am on the new dynamic pages page
+    And I fill in "dynamic_page_title" with "Test Title"
+    And I fill in "dynamic_page_slug" with "test_slug"
+    And I choose "inlineRadioAdmin"
+    And I fill in the dynamic_page_body with "This is a test"
+    And I press "Submit"
+    And I follow "Pages"
+    And I press the edit button for "test_slug"
+    Then I should be on the edit dynamic pages page for "test_slug"
+    And I press "Update"
+    Then I should be on the dynamic pages index
+    And I should see "Test Title"
+    And I should see "test_slug"
+
+Scenario: Attempting to update page with taken slug doesn't delete form input
+    Given I am on the new dynamic pages page
+    And I fill in "dynamic_page_title" with "Test Title"
+    And I fill in "dynamic_page_slug" with "test_slug"
+    And I choose "inlineRadioAdmin"
+    And I fill in the dynamic_page_body with "This is a test"
+    And I press "Submit"
+    Given I am on the new dynamic pages page
+    And I fill in "dynamic_page_title" with "Test Title 2"
+    And I fill in "dynamic_page_slug" with "test_slug_2"
+    And I choose "inlineRadioAdmin"
+    And I fill in the dynamic_page_body with "This is a test"
+    And I press "Submit"
+    Then I follow "Pages"
+    And I press the edit button for "test_slug_2"
+    Then I should be on the edit dynamic pages page for "test_slug_2"
+    And I fill in "dynamic_page_title" with "New Title"
+    And I fill in "dynamic_page_slug" with "test_slug"
+    And I fill in the dynamic_page_body with "New page body."
+    And I press "Update"
+    Then I should be on the edit dynamic pages page for "test_slug_2"
+    And the "dynamic_page_title" field should contain "New Title"
+    And the "dynamic_page_slug" field should contain "test_slug"
+    And I should see "New page body."


### PR DESCRIPTION
The implementation actually still redirects, but uses flash to carry over the input from the form so that it can be repopulated when reloading the page. Pair programmed with Steve