### PR TITLE
181591582 fix permissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,4 +97,6 @@ group :test do
   # Accessibility Testing
   gem "axe-core-rspec"
   gem "axe-core-cucumber"
+
+  gem 'rails-controller-testing'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -98,5 +98,5 @@ group :test do
   gem "axe-core-rspec"
   gem "axe-core-cucumber"
 
-  gem 'rails-controller-testing'
+  gem "rails-controller-testing"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,6 +404,10 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.4.4)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -612,6 +616,7 @@ DEPENDENCIES
   puma (~> 5)
   rack-mini-profiler (~> 2.0)
   rails (~> 6)
+  rails-controller-testing
   rspec-rails
   rubocop
   rubocop-faker

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,10 @@ class ApplicationController < ActionController::Base
     @is_teacher ||= logged_in? ? !current_user.admin : false
   end
 
+  def is_verified_teacher?
+    @is_verified_teacher ||= logged_in? ? (!current_user.admin) && (current_user.display_application_status == "Validated") : false
+  end
+
   def require_login
     unless logged_in?
       flash[:danger] = "You need to log in to access this."

--- a/app/controllers/dynamic_pages_controller.rb
+++ b/app/controllers/dynamic_pages_controller.rb
@@ -3,6 +3,11 @@
 class DynamicPagesController < ApplicationController
   before_action :require_admin, except: [:index, :show]
   def index
+    if session[:user_id]
+      @current_user_is_admin = is_admin?
+      @current_user_is_teacher = is_teacher?
+      @current_user_is_verified_teacher = is_verified_teacher?
+    end
     @all_dynamic_pages = DynamicPage.all
   end
   def delete
@@ -28,7 +33,7 @@ class DynamicPagesController < ApplicationController
     @dynamic_page = DynamicPage.find_by(slug: params[:slug])
     if @dynamic_page.permissions == "Admin" && !is_admin?
       redirect_to dynamic_pages_path, alert: "You do not have permission to view that page!"
-    elsif @dynamic_page.permissions == "Verified Teacher" && (!logged_in?)
+    elsif @dynamic_page.permissions == "Verified Teacher" && (!is_admin?) && (!is_verified_teacher?)
       redirect_to dynamic_pages_path, alert: "You do not have permission to view that page!"
     end
   end

--- a/app/controllers/dynamic_pages_controller.rb
+++ b/app/controllers/dynamic_pages_controller.rb
@@ -26,6 +26,11 @@ class DynamicPagesController < ApplicationController
   end
   def show
     @dynamic_page = DynamicPage.find_by(slug: params[:slug])
+    if @dynamic_page.permissions == "Admin" && !is_admin?
+      redirect_to dynamic_pages_path, alert: "You do not have permission to view that page!"
+    elsif @dynamic_page.permissions == "Verified Teacher" && (!logged_in?)
+      redirect_to dynamic_pages_path, alert: "You do not have permission to view that page!"
+    end
   end
   def edit
     @dynamic_page = DynamicPage.find_by(slug: params[:slug])

--- a/app/controllers/dynamic_pages_controller.rb
+++ b/app/controllers/dynamic_pages_controller.rb
@@ -3,7 +3,7 @@
 class DynamicPagesController < ApplicationController
   before_action :require_admin, except: [:index, :show]
   def index
-    if session[:user_id]
+    if logged_in?
       @current_user_is_admin = is_admin?
       @current_user_is_teacher = is_teacher?
       @current_user_is_verified_teacher = is_verified_teacher?

--- a/app/views/dynamic_pages/index.html.erb
+++ b/app/views/dynamic_pages/index.html.erb
@@ -27,24 +27,16 @@
   </thead>
   <tbody>
     <% @all_dynamic_pages.each do |p| %>
-      <% if p.permissions == "Public" %>
+      <% if p.permissions == "Public" || 
+            @current_user_is_admin ||
+            (p.permissions == "Verified Teacher" && @current_user_is_verified_teacher)
+      %>
         <tr align = "center">
           <td> <%= link_to(p.title, controller: "dynamic_pages", action: "show", slug: p.slug) %> </td>
           <td> <%= p.slug %> </td>
           <td> <%= Teacher.find(p.last_editor).full_name %> </td>
           <td> <%= p.created_at %> </td>
-          <% if session[:user_id] && Teacher.find(session[:user_id]).admin %>
-            <td> <%= button_to("Edit", {action: "edit", slug: p.slug}, method: :get, class: "btn btn-primary", type: 'button', id: "edit_"+p.slug) %> </td>
-            <td> <%= button_to("Delete", {action: "delete", id: p.id}, class: "btn btn-danger", type: 'button', id: "delete_"+p.slug) %> </td>
-          <% end %>
-        </tr>
-      <% elsif session[:user_id] && (Teacher.find(session[:user_id]).admin || p.permissions != "Admin") %>
-        <tr align = "center">
-          <td> <%= link_to(p.title, controller: "dynamic_pages", action: "show", slug: p.slug) %> </td>
-          <td> <%= p.slug %> </td>
-          <td> <%= Teacher.find(p.last_editor).full_name %> </td>
-          <td> <%= p.created_at %> </td>
-          <% if Teacher.find(session[:user_id]).admin %>
+          <% if @current_user_is_admin %>
             <td> <%= button_to("Edit", {action: "edit", slug: p.slug}, method: :get, class: "btn btn-primary", type: 'button', id: "edit_"+p.slug) %> </td>
             <td> <%= button_to("Delete", {action: "delete", id: p.id}, class: "btn btn-danger", type: 'button', id: "delete_"+p.slug) %> </td>
           <% end %>

--- a/features/dynamic_pages_permissions.feature
+++ b/features/dynamic_pages_permissions.feature
@@ -105,6 +105,14 @@ Scenario: Teachers can access teacher pages
     And I should see "Test Teacher Page"
     And I should see "Test teacher body."
 
+Scenario: Teachers can't access admin pages
+    Given I am on the BJC home page
+    Given I have a teacher Google email
+    And I follow "Log In"
+    Then I can log in with Google
+    Given I am on the dynamic page for slug "test_slug_admin"
+    Then I should be on the dynamic pages index
+
 Scenario: Public can access public pages
     Given I am on the BJC home page
     Then I follow "Pages"
@@ -113,3 +121,11 @@ Scenario: Public can access public pages
     Then I should be on the dynamic page for slug "test_slug_public"
     And I should see "Test Public Page"
     And I should see "Test public body."
+
+Scenario: Public can't access verified teacher pages
+    Given I am on the dynamic page for slug "test_slug_verified_teacher"
+    Then I should be on the dynamic pages index
+
+Scenario: Public can't access admin pages
+    Given I am on the dynamic page for slug "test_slug_admin"
+    Then I should be on the dynamic pages index

--- a/features/dynamic_pages_permissions.feature
+++ b/features/dynamic_pages_permissions.feature
@@ -5,14 +5,14 @@ Feature: dynamic pages features a verified teacher
 Background: Has admin and teacher in DB along with pages of each permission type
     Given I seed data
     Given the following teachers exist:
-    | first_name | last_name | admin | email                        |
-    | Joseph     | Mamoa     | true  | testadminuser@berkeley.edu   |
-    | Todd       | Teacher   | false | testteacher@berkeley.edu     |
+    | first_name | last_name | admin | email                        | application_status |
+    | Joseph     | Mamoa     | true  | testadminuser@berkeley.edu   | Pending            |
+    | Todd       | Teacher   | false | testteacher@berkeley.edu     | Validated          |
     Given the following dynamic pages exist:
-    | slug | title | body | permissions                        |
-    | test_slug_admin            | Test Admin Page   | Test admin body.   | Admin   |
+    | slug                       | title             | body               | permissions      |
+    | test_slug_admin            | Test Admin Page   | Test admin body.   | Admin            |
     | test_slug_verified_teacher | Test Teacher Page | Test teacher body. | Verified Teacher |
-    | test_slug_public           | Test Public Page  | Test public body.  | Public   |
+    | test_slug_public           | Test Public Page  | Test public body.  | Public           |
 
 Scenario: Admins can see everything
     Given I am on the BJC home page

--- a/spec/controllers/dynamic_pages_controller_spec.rb
+++ b/spec/controllers/dynamic_pages_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DynamicPagesController, type: :controller do
     it "renders the index template" do
       expect(DynamicPage).to receive(:all)
       get :index
-      expect(response).to render_template('index')
+      expect(response).to render_template("index")
     end
   end
 
@@ -203,5 +203,4 @@ RSpec.describe DynamicPagesController, type: :controller do
       expect(@slug_exists_flash_alert).to match flash[:alert]
     end
   end
-
 end

--- a/spec/controllers/dynamic_pages_controller_spec.rb
+++ b/spec/controllers/dynamic_pages_controller_spec.rb
@@ -13,162 +13,195 @@ RSpec.describe DynamicPagesController, type: :controller do
     @success_flash_alert = Regexp.new("Created #{@dynamic_page_title} page successfully.")
   end
 
-  it "allows admin to create" do
-    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    post :create, {
-        params: {
+  describe "#index" do
+    it "renders the index template" do
+      expect(DynamicPage).to receive(:all)
+      get :index
+      expect(response).to render_template('index')
+    end
+  end
+
+  describe "#delete" do
+    before :each do
+      fake_page_hash = {
+        slug: @dynamic_page_slug,
+        title: @dynamic_page_title,
+        body: "<p>Test page body.</p>",
+        permissions: "Admin",
+        creator_id: 0,
+        last_editor: 0
+      }
+      DynamicPage.create!(fake_page_hash)
+    end
+
+    it "deletes the page" do
+      allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+      id_to_delete = DynamicPage.find_by(slug: @dynamic_page_slug).id
+      expect(DynamicPage).to receive(:destroy)
+      delete :delete, { params: { id: id_to_delete } }
+      expect(response).to redirect_to(dynamic_pages_path)
+    end
+  end
+
+  describe "#create" do
+    it "allows admin to create" do
+      allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+      post :create, {
+          params: {
+              dynamic_page: {
+                  slug: @dynamic_page_slug,
+                  title: @dynamic_page_title,
+                  body: "<p>Test page body.</p>",
+                  permissions: "Admin",
+                  creator_id: 0,
+                  last_editor: 0
+              }
+          }
+      }
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).not_to be_nil
+      expect(@success_flash_alert).to match flash[:success]
+    end
+
+    it "denies teacher to create" do
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+      post :create, {
+          params: {
             dynamic_page: {
-                slug: @dynamic_page_slug,
-                title: @dynamic_page_title,
-                body: "<p>Test page body.</p>",
-                permissions: "Admin",
-                creator_id: 0,
-                last_editor: 0
+              slug: @dynamic_page_slug,
+              title: @dynamic_page_title,
+              body: "<p>Test page body.</p>",
+              permissions: "Admin",
+              creator_id: 0,
+              last_editor: 0
             }
-        }
-    }
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).not_to be_nil
-    expect(@success_flash_alert).to match flash[:success]
-  end
-
-  it "denies teacher to create" do
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    post :create, {
-        params: {
-          dynamic_page: {
-            slug: @dynamic_page_slug,
-            title: @dynamic_page_title,
-            body: "<p>Test page body.</p>",
-            permissions: "Admin",
-            creator_id: 0,
-            last_editor: 0
           }
-        }
-    }
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-  end
-
-  it "requires slug to create" do
-    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    expect { post :create, {
-        params: {
-          dynamic_page: {
-            title: @dynamic_page_title,
-            body: "<p>Test page body.</p>",
-            permissions: "Admin",
-            creator_id: 0,
-            last_editor: 0
-          }
-        }
       }
-    }.to raise_error(ActionController::ParameterMissing)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-  end
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+    end
 
-  it "requires title to create" do
-    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    expect { post :create, {
-        params: {
-          dynamic_page: {
-            slug: @dynamic_page_slug,
-            body: "<p>Test page body.</p>",
-            permissions: "Admin",
-            creator_id: 0,
-            last_editor: 0
-          }
-        }
-      }
-    }.to raise_error(ActionController::ParameterMissing)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-  end
-
-  it "requires permissions to create" do
-    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    expect { post :create, {
-        params: {
-          dynamic_page: {
-            title: @dynamic_page_title,
-            slug: @dynamic_page_slug,
-            body: "<p>Test page body.</p>",
-            creator_id: 0,
-            last_editor: 0
-          }
-        }
-      }
-    }.to raise_error(ActionController::ParameterMissing)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-  end
-
-  it "requires creator_id to create" do
-    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    expect { post :create, {
-        params: {
-          dynamic_page: {
-            title: @dynamic_page_title,
-            slug: @dynamic_page_slug,
-            body: "<p>Test page body.</p>",
-            permissions: "Admin",
-            last_editor: 0
-          }
-        }
-      }
-    }.to raise_error(ActionController::ParameterMissing)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-  end
-
-  it "requires last_editor to create" do
-    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    expect { post :create, {
-        params: {
-          dynamic_page: {
-            title: @dynamic_page_title,
-            slug: @dynamic_page_slug,
-            body: "<p>Test page body.</p>",
-            permissions: "Admin",
-            last_editor: 0
-          }
-        }
-      }
-    }.to raise_error(ActionController::ParameterMissing)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-  end
-
-  it "prevents submitting multiple pages with same slug" do
-    allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
-    post :create, {
-        params: {
+    it "requires slug to create" do
+      allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+      expect { post :create, {
+          params: {
             dynamic_page: {
-                slug: @dynamic_page_slug,
-                title: @dynamic_page_title,
-                body: "<p>Test page body.</p>",
-                permissions: "Admin",
-                creator_id: 0,
-                last_editor: 0
+              title: @dynamic_page_title,
+              body: "<p>Test page body.</p>",
+              permissions: "Admin",
+              creator_id: 0,
+              last_editor: 0
             }
+          }
         }
-    }
-    expect(DynamicPage.find_by(slug: @dynamic_page_slug)).not_to be_nil
-    expect(@success_flash_alert).to match flash[:success]
+      }.to raise_error(ActionController::ParameterMissing)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+    end
 
-    post :create, {
-        params: {
+    it "requires title to create" do
+      allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+      expect { post :create, {
+          params: {
             dynamic_page: {
-                slug: @dynamic_page_slug,
-                title: @dynamic_page_title,
-                body: "<p>Test page body.</p>",
-                permissions: "Admin",
-                creator_id: 0,
-                last_editor: 0
+              slug: @dynamic_page_slug,
+              body: "<p>Test page body.</p>",
+              permissions: "Admin",
+              creator_id: 0,
+              last_editor: 0
             }
+          }
         }
-    }
-    expect(@slug_exists_flash_alert).to match flash[:alert]
+      }.to raise_error(ActionController::ParameterMissing)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+    end
+
+    it "requires permissions to create" do
+      allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+      expect { post :create, {
+          params: {
+            dynamic_page: {
+              title: @dynamic_page_title,
+              slug: @dynamic_page_slug,
+              body: "<p>Test page body.</p>",
+              creator_id: 0,
+              last_editor: 0
+            }
+          }
+        }
+      }.to raise_error(ActionController::ParameterMissing)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+    end
+
+    it "requires creator_id to create" do
+      allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+      expect { post :create, {
+          params: {
+            dynamic_page: {
+              title: @dynamic_page_title,
+              slug: @dynamic_page_slug,
+              body: "<p>Test page body.</p>",
+              permissions: "Admin",
+              last_editor: 0
+            }
+          }
+        }
+      }.to raise_error(ActionController::ParameterMissing)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+    end
+
+    it "requires last_editor to create" do
+      allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+      expect { post :create, {
+          params: {
+            dynamic_page: {
+              title: @dynamic_page_title,
+              slug: @dynamic_page_slug,
+              body: "<p>Test page body.</p>",
+              permissions: "Admin",
+              last_editor: 0
+            }
+          }
+        }
+      }.to raise_error(ActionController::ParameterMissing)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+    end
+
+    it "prevents submitting multiple pages with same slug" do
+      allow_any_instance_of(ApplicationController).to receive(:require_admin).and_return(true)
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).to be_nil
+      post :create, {
+          params: {
+              dynamic_page: {
+                  slug: @dynamic_page_slug,
+                  title: @dynamic_page_title,
+                  body: "<p>Test page body.</p>",
+                  permissions: "Admin",
+                  creator_id: 0,
+                  last_editor: 0
+              }
+          }
+      }
+      expect(DynamicPage.find_by(slug: @dynamic_page_slug)).not_to be_nil
+      expect(@success_flash_alert).to match flash[:success]
+
+      post :create, {
+          params: {
+              dynamic_page: {
+                  slug: @dynamic_page_slug,
+                  title: @dynamic_page_title,
+                  body: "<p>Test page body.</p>",
+                  permissions: "Admin",
+                  creator_id: 0,
+                  last_editor: 0
+              }
+          }
+      }
+      expect(@slug_exists_flash_alert).to match flash[:alert]
+    end
   end
+
 end


### PR DESCRIPTION
The dynamic pages controller now has functionality to redirect unauthorized users to the index page. Index page filtering also fixed so that unverified teachers cannot view pages for verified teachers.