### PR TITLE
dynamic_pages index cleanup

### DIFF
--- a/app/views/dynamic_pages/index.html.erb
+++ b/app/views/dynamic_pages/index.html.erb
@@ -16,10 +16,9 @@
   <thead class="thead-dark">
     <tr align = "center">
     <th scope="col">Title</th>
-    <th scope="col">Slug</th>
     <th scope="col">Last Editor</th>
-    <th scope="col">Created At</th>
     <% if session[:user_id] && Teacher.find(session[:user_id]).admin %>
+      <th scope="col">Permissions</th>
       <th scope="col">Edit</th>
       <th scope="col">Delete</th>
     <% end %>
@@ -33,10 +32,9 @@
       %>
         <tr align = "center">
           <td> <%= link_to(p.title, controller: "dynamic_pages", action: "show", slug: p.slug) %> </td>
-          <td> <%= p.slug %> </td>
           <td> <%= Teacher.find(p.last_editor).full_name %> </td>
-          <td> <%= p.created_at %> </td>
           <% if @current_user_is_admin %>
+            <td> <%= p.permissions %> </td>
             <td> <%= button_to("Edit", {action: "edit", slug: p.slug}, method: :get, class: "btn btn-primary", type: 'button', id: "edit_"+p.slug) %> </td>
             <td> <%= button_to("Delete", {action: "delete", id: p.id}, class: "btn btn-danger", type: 'button', id: "delete_"+p.slug) %> </td>
           <% end %>

--- a/features/dynamic_pages_admin.feature
+++ b/features/dynamic_pages_admin.feature
@@ -17,7 +17,7 @@ Scenario: Pressing "Dynamic Pages" button on navbar should take me to a list of 
     Given I follow "Pages"
     Then I should be on the dynamic pages index
     And I should see "Title"
-    And I should see "Slug"
+    And I should see "Permissions"
     And I should not see "Body"
 
 Scenario: Pressing "New Page" button should take user to new page form
@@ -70,7 +70,7 @@ Scenario: I create a new page and I can see it on the index page
     And I press "Submit"
     And I follow "Pages"
     Then I should see "Test Title"
-    And I should see "test_slug"
+    And I should see "Admin"
 
 Scenario: Can create a new page with the same title as a page that already exists
     Given I am on the new dynamic pages page
@@ -179,7 +179,7 @@ Scenario: Can edit pages with correct prefilled content in the form.
     And I fill in the dynamic_page_body with "This is a test 2"
     And I press "Update"
     Then I should see "New Title"
-    And I should see "new_slug"
+    And I should see "Public"
     Then I should be on the dynamic pages index
     And I should not see "Test Title"
     And I should not see "test_slug"
@@ -197,7 +197,7 @@ Scenario: Can update page even if no changes
     And I press "Update"
     Then I should be on the dynamic pages index
     And I should see "Test Title"
-    And I should see "test_slug"
+    And I should see "Admin"
 
 Scenario: Attempting to update page with taken slug doesn't delete form input
     Given I am on the new dynamic pages page


### PR DESCRIPTION
Remove slug and created_at from dynamic_pages index table. Added the permissions column when user is an admin.