### PR TITLE
181829576 refactor schools

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -23,6 +23,12 @@ class SchoolsController < ApplicationController
 
   private
     def school_params
+      if params[:school] # Validate input for nces_id
+        if params[:school][:nces_id] && (params[:school][:nces_id].to_i < 0 || 999999999999 < params[:school][:nces_id].to_i)
+          raise ArgumentError.new("Invalid nces_id")
+        end
+      end
+
       params.require(:school).permit(:name, :city, :state, :website, :grade_level, :school_type, :tags, :nces_id)
     end
 

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class SchoolsController < ApplicationController
+  before_action :sanitize_params, only: [:new, :create, :edit, :update]
   before_action :require_admin
   def create
     @school = School.new(school_params)
@@ -22,6 +23,17 @@ class SchoolsController < ApplicationController
 
   private
     def school_params
-      params.require(:school).permit(:name, :city, :state, :website, :grade_level, :type, :tags, :nces_id)
+      params.require(:school).permit(:name, :city, :state, :website, :grade_level, :school_type, :tags, :nces_id)
+    end
+
+    def sanitize_params
+      if params[:school]
+        if params[:school][:grade_level]
+          params[:school][:grade_level] = params[:school][:grade_level].to_i
+        end
+        if params[:school][:school_type]
+          params[:school][:school_type] = params[:school][:school_type].to_i
+        end
+      end
     end
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -22,6 +22,6 @@ class SchoolsController < ApplicationController
 
   private
     def school_params
-      params.require(:school).permit(:name, :city, :state, :website)
+      params.require(:school).permit(:name, :city, :state, :website, :grade_level, :type, :tags, :nces_id)
     end
 end

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -142,7 +142,7 @@ class TeachersController < ApplicationController
     end
 
     def school_params
-      params.require(:school).permit(:name, :city, :state, :website)
+      params.require(:school).permit(:name, :city, :state, :website, :grade_level, :school_type, :tags, :nces_id)
     end
 
     def sanitize_params
@@ -152,6 +152,15 @@ class TeachersController < ApplicationController
         end
         if params[:teacher][:education_level]
           params[:teacher][:education_level] = params[:teacher][:education_level].to_i
+        end
+      end
+
+      if params[:school]
+        if params[:school][:grade_level]
+          params[:school][:grade_level] = params[:school][:grade_level].to_i
+        end
+        if params[:school][:school_type]
+          params[:school][:school_type] = params[:school][:school_type].to_i
         end
       end
     end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -12,10 +12,10 @@
 #  name                   :string
 #  num_denied_teachers    :integer          default(0)
 #  num_validated_teachers :integer          default(0)
+#  school_type            :integer
 #  state                  :string
 #  tags                   :text             default([]), is an Array
 #  teachers_count         :integer          default(0)
-#  type                   :integer
 #  website                :string
 #  created_at             :datetime
 #  updated_at             :datetime
@@ -48,7 +48,7 @@ class School < ApplicationRecord
     university: 4
   } 
 
-  enum type: {
+  enum school_type: {
     public: 0,
     private: 1,
     charter: 2,
@@ -70,7 +70,7 @@ class School < ApplicationRecord
   end
 
   def self.school_type_options
-    School.types.map { |sym, val| [sym.to_s.titlecase, val] }
+    School.school_types.map { |sym, val| [sym.to_s.titlecase, val] }
   end
 
   private

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -19,7 +19,7 @@
 #  website                :string
 #  created_at             :datetime
 #  updated_at             :datetime
-#  nces_id                :integer
+#  nces_id                :bigint
 #
 # Indexes
 #
@@ -46,7 +46,7 @@ class School < ApplicationRecord
     high_school: 2,
     community_college: 3,
     university: 4
-  } 
+  }
 
   enum school_type: {
     public: 0,

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -40,6 +40,23 @@ class School < ApplicationRecord
   MAPS_API_KEY = ENV["MAPS_API_KEY"]
   GOOGLE_MAPS = "https://maps.googleapis.com/maps/api/geocode/"
 
+  enum grade_level: {
+    elementary: 0,
+    middle_school: 1,
+    high_school: 2,
+    community_college: 3,
+    university: 4
+  }
+
+  enum type: {
+    public: 0,
+    private: 1,
+    charter: 2,
+    magnet: 3,
+    alternative: 4,
+    other: 5
+  }, _prefix: :school_type
+
   def website
     prefix_url(self[:website])
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -6,16 +6,20 @@
 #
 #  id                     :bigint           not null, primary key
 #  city                   :string
+#  grade_level            :integer
 #  lat                    :float
 #  lng                    :float
 #  name                   :string
 #  num_denied_teachers    :integer          default(0)
 #  num_validated_teachers :integer          default(0)
 #  state                  :string
+#  tags                   :text             default([]), is an Array
 #  teachers_count         :integer          default(0)
+#  type                   :integer
 #  website                :string
 #  created_at             :datetime
 #  updated_at             :datetime
+#  nces_id                :integer
 #
 # Indexes
 #

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -46,7 +46,7 @@ class School < ApplicationRecord
     high_school: 2,
     community_college: 3,
     university: 4
-  }
+  } 
 
   enum type: {
     public: 0,
@@ -63,6 +63,14 @@ class School < ApplicationRecord
 
   def location
     "#{city}, #{state}"
+  end
+
+  def self.grade_level_options
+    School.grade_levels.map { |sym, val| [sym.to_s.titlecase, val] }
+  end
+
+  def self.school_type_options
+    School.types.map { |sym, val| [sym.to_s.titlecase, val] }
   end
 
   private

--- a/app/views/schools/_form.html.erb
+++ b/app/views/schools/_form.html.erb
@@ -39,9 +39,9 @@
 </div>
 
 <div class="form-group">
-  <%= fields.label :type, "School Type", class: "label-required" %>
+  <%= fields.label :school_type, "School Type", class: "label-required" %>
   <%= fields.select(
-          :type,
+          :school_type,
           options_for_select(School.school_type_options),
           { include_blank: "Select an option" },
           { class: 'form-control', required: true }
@@ -80,7 +80,7 @@
 
   <div class="form-group">
     <%= fields.label :nces_id, "NCES ID", class: "label-required" %>
-    <%= fields.number_field :website, placeholder: "000000000000",
+    <%= fields.number_field :nces_id, placeholder: "000000000000",
         class: "form-control", required: true, pattern: "^\d{12}$", title: "Please enter a valid NCES ID." %>
   </div>
 <% end %>

--- a/app/views/schools/_form.html.erb
+++ b/app/views/schools/_form.html.erb
@@ -81,6 +81,6 @@
   <div class="form-group">
     <%= fields.label :nces_id, "NCES ID", class: "label-required" %>
     <%= fields.number_field :nces_id, placeholder: "000000000000",
-        class: "form-control", required: true, pattern: "^\d{12}$", title: "Please enter a valid NCES ID." %>
+        class: "form-control", required: true, max: 999999999999, title: "Please enter a valid NCES ID." %>
   </div>
 <% end %>

--- a/app/views/schools/_form.html.erb
+++ b/app/views/schools/_form.html.erb
@@ -29,22 +29,22 @@
 </div>
 
 <div class="form-group">
-  <%= fields.label :grade_level, "Grade Level", class: "label-required" %>
+  <%= fields.label :grade_level, "Grade Level" %>
   <%= fields.select(
           :grade_level,
           options_for_select(School.grade_level_options),
           { include_blank: "Select an option" },
-          { class: 'form-control', required: true }
+          { class: 'form-control', required: false }
         ) %>
 </div>
 
 <div class="form-group">
-  <%= fields.label :school_type, "School Type", class: "label-required" %>
+  <%= fields.label :school_type, "School Type" %>
   <%= fields.select(
           :school_type,
           options_for_select(School.school_type_options),
           { include_blank: "Select an option" },
-          { class: 'form-control', required: true }
+          { class: 'form-control', required: false }
         ) %>
 </div>
 

--- a/app/views/schools/_form.html.erb
+++ b/app/views/schools/_form.html.erb
@@ -23,7 +23,64 @@
 </div>
 
 <div class="form-group">
-<%= fields.label :website, "School Website", class: "label-required" %>
-<%= fields.text_field :website, placeholder: "snap.berkeley.edu",
-    class: "form-control", required: true, pattern: ".+\\..+", title: "Please enter a valid URL." %>
+  <%= fields.label :website, "School Website", class: "label-required" %>
+  <%= fields.text_field :website, placeholder: "snap.berkeley.edu",
+      class: "form-control", required: true, pattern: ".+\\..+", title: "Please enter a valid URL." %>
 </div>
+
+<div class="form-group">
+  <%= fields.label :grade_level, "Grade Level", class: "label-required" %>
+  <%= fields.select(
+          :grade_level,
+          options_for_select(School.grade_level_options),
+          { include_blank: "Select an option" },
+          { class: 'form-control', required: true }
+        ) %>
+</div>
+
+<div class="form-group">
+  <%= fields.label :type, "School Type", class: "label-required" %>
+  <%= fields.select(
+          :type,
+          options_for_select(School.school_type_options),
+          { include_blank: "Select an option" },
+          { class: 'form-control', required: true }
+        ) %>
+</div>
+
+
+<% if logged_in? ? current_user.admin : false %>
+  <%= fields.label :tags, "Tags" %>
+  <div class="form-group row">
+    <div class='col-2'>
+      <%= fields.text_field :tags, placeholder: "Tag Name", multiple: true,
+          class: "form-control" %>
+    </div>
+    <div class='col-2'>
+      <%= fields.text_field :tags, placeholder: "Tag Name", multiple: true,
+          class: "form-control" %>
+    </div>
+    <div class='col-2'>
+      <%= fields.text_field :tags, placeholder: "Tag Name", multiple: true,
+          class: "form-control" %>
+    </div>
+    <div class='col-2'>
+      <%= fields.text_field :tags, placeholder: "Tag Name", multiple: true,
+          class: "form-control" %>
+    </div>
+    <div class='col-2'>
+      <%= fields.text_field :tags, placeholder: "Tag Name", multiple: true,
+          class: "form-control" %>
+    </div>
+    <div class='col-2'>
+      <%= fields.text_field :tags, placeholder: "Tag Name", multiple: true,
+          class: "form-control" %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= fields.label :nces_id, "NCES ID", class: "label-required" %>
+    <%= fields.number_field :website, placeholder: "000000000000",
+        class: "form-control", required: true, pattern: "^\d{12}$", title: "Please enter a valid NCES ID." %>
+  </div>
+<% end %>

--- a/app/views/schools/_form.html.erb
+++ b/app/views/schools/_form.html.erb
@@ -79,8 +79,8 @@
   </div>
 
   <div class="form-group">
-    <%= fields.label :nces_id, "NCES ID", class: "label-required" %>
+    <%= fields.label :nces_id, "NCES ID" %>
     <%= fields.number_field :nces_id, placeholder: "000000000000",
-        class: "form-control", required: true, max: 999999999999, title: "Please enter a valid NCES ID." %>
+        class: "form-control", max: 999999999999, title: "Please enter a valid NCES ID." %>
   </div>
 <% end %>

--- a/db/migrate/20220416215843_schools_model_refactor.rb
+++ b/db/migrate/20220416215843_schools_model_refactor.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SchoolsModelRefactor < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :grade_level, :integer
+    add_column :schools, :type, :integer
+    add_column :schools, :tags, :text, array: true, default: []
+    add_column :schools, :nces_id, :integer
+  end
+end

--- a/db/migrate/20220417022218_rename_school_type_field.rb
+++ b/db/migrate/20220417022218_rename_school_type_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameSchoolTypeField < ActiveRecord::Migration[6.1]
   def change
     rename_column :schools, :type, :school_type

--- a/db/migrate/20220417022218_rename_school_type_field.rb
+++ b/db/migrate/20220417022218_rename_school_type_field.rb
@@ -1,0 +1,5 @@
+class RenameSchoolTypeField < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :schools, :type, :school_type
+  end
+end

--- a/db/migrate/20220417030705_change_schools_nces_id_to_big_int.rb
+++ b/db/migrate/20220417030705_change_schools_nces_id_to_big_int.rb
@@ -1,0 +1,5 @@
+class ChangeSchoolsNcesIdToBigInt < ActiveRecord::Migration[6.1]
+  def change
+    change_column :schools, :nces_id, :bigint
+  end
+end

--- a/db/migrate/20220417030705_change_schools_nces_id_to_big_int.rb
+++ b/db/migrate/20220417030705_change_schools_nces_id_to_big_int.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeSchoolsNcesIdToBigInt < ActiveRecord::Migration[6.1]
   def change
     change_column :schools, :nces_id, :bigint

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_04_17_030705) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_17_022218) do
+ActiveRecord::Schema.define(version: 2022_04_17_030705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,7 +91,7 @@ ActiveRecord::Schema.define(version: 2022_04_17_022218) do
     t.integer "grade_level"
     t.integer "school_type"
     t.text "tags", default: [], array: true
-    t.integer "nces_id"
+    t.bigint "nces_id"
     t.index ["name", "city", "website"], name: "index_schools_on_name_city_and_website"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_16_215843) do
+ActiveRecord::Schema.define(version: 2022_04_17_022218) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,7 +89,7 @@ ActiveRecord::Schema.define(version: 2022_04_16_215843) do
     t.datetime "updated_at", default: -> { "now()" }
     t.integer "num_denied_teachers", default: 0
     t.integer "grade_level"
-    t.integer "type"
+    t.integer "school_type"
     t.text "tags", default: [], array: true
     t.integer "nces_id"
     t.index ["name", "city", "website"], name: "index_schools_on_name_city_and_website"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_29_232458) do
+ActiveRecord::Schema.define(version: 2022_04_16_215843) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,6 +89,10 @@ ActiveRecord::Schema.define(version: 2022_03_29_232458) do
     t.datetime "created_at", default: -> { "now()" }
     t.datetime "updated_at", default: -> { "now()" }
     t.integer "num_denied_teachers", default: 0
+    t.integer "grade_level"
+    t.integer "type"
+    t.text "tags", default: [], array: true
+    t.integer "nces_id"
     t.index ["name", "city", "website"], name: "index_schools_on_name_city_and_website"
   end
 

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -77,8 +77,8 @@ Scenario: Non-admin, unregistered user should not be able to see admin-only page
 
 Scenario: Edit teacher info as an admin
   Given the following schools exist:
-  |       name      |     city     |  state  |            website            |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
   Given the following teachers exist:
   | first_name | last_name | admin | email                    | school      | snap   |
   | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley | alonzo |
@@ -98,8 +98,8 @@ Scenario: Edit teacher info as an admin
 
 Scenario: Deny teacher as an admin
   Given the following schools exist:
-  |       name      |     city     |  state  |            website            |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
   Given the following teachers exist:
   | first_name | last_name | admin | email                    | school      |
   | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
@@ -120,8 +120,8 @@ Scenario: Deny teacher as an admin
 
 Scenario: Not logged in should not have access to edit
   Given the following schools exist:
-  |       name      |     city     |  state  |            website            |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
   Given the following teachers exist:
   | first_name | last_name | admin | email                    | school      |
   | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
@@ -130,8 +130,8 @@ Scenario: Not logged in should not have access to edit
 
 Scenario: Filter all teacher info as an admin
   Given the following schools exist:
-  |       name      |     city     |  state  |            website            |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
   Given the following teachers exist:
   | first_name | last_name  | admin | email                     | school      | application_status |
   | Victor     | Validateme | false | testteacher1@berkeley.edu | UC Berkeley |      Validated     |
@@ -153,8 +153,8 @@ Scenario: Filter all teacher info as an admin
 
 Scenario: View teacher info as an admin
   Given the following schools exist:
-  |       name      |     city     |  state  |            website            |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
   Given the following teachers exist:
   | first_name | last_name | admin | email                    | school      | snap   |
   | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley | alonzo |
@@ -174,8 +174,8 @@ Scenario: View teacher info as an admin
 
 Scenario: Edit teacher info as an admin navigating from view only page to edit page
   Given the following schools exist:
-  |       name      |     city     |  state  |            website            |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
   Given the following teachers exist:
   | first_name | last_name | admin | email                    | school      | snap   |
   | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley | alonzo |
@@ -198,8 +198,8 @@ Scenario: Edit teacher info as an admin navigating from view only page to edit p
 
 Scenario: Should be able to resend welcome email
   Given the following schools exist:
-  |       name      |     city     |  state  |            website            |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
   Given the following teachers exist:
   | first_name | last_name | admin | email                    | school      | snap   | application_status |
   | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley | alonzo | validated |

--- a/features/form_submission.feature
+++ b/features/form_submission.feature
@@ -189,3 +189,8 @@ Scenario: Filling out form should have the correct information in a Teacher
     Then the "more_info" of the user with email "bbaker@berkeley.edu" should be "Rebecca"
     Then the "personal_website" of the user with email "bbaker@berkeley.edu" should be "https://www.bobbaker.io"
     Then the "education_level" of the user with email "bbaker@berkeley.edu" should be "high_school"
+
+Scenario: Teachers creating their account should not be able to input Tags or NCES ID for their school.
+    Given I am on the BJC home page
+    Then I should not see "Tags"
+    And I should not see "NCIS ID"

--- a/features/form_submission.feature
+++ b/features/form_submission.feature
@@ -23,6 +23,8 @@ Scenario: Correctly filling out and succesful form submission
     And   I enter my "City" as "Cupertino"
     And   I select "CA" from "State"
     And   I enter my "School Website" as "https://chs.fuhsd.org"
+    And   I select "University" from "Grade Level"
+    And   I select "Public" from "School Type"
     And   I press "Submit"
     Then  I see a confirmation "Thanks for signing up for BJC"
 
@@ -35,6 +37,8 @@ Scenario: Not Correctly filling out and unsuccesful form submission
     And   I enter my "City" as "Cupertino"
     And   I select "CA" from "State"
     And   I enter my "School Website" as "chs.fuhsd.org"
+    And   I select "University" from "Grade Level"
+    And   I select "Public" from "School Type"
     And   I press "Submit"
     Then  The "#new_teacher" form is invalid
     And  I am on the BJC home page
@@ -51,6 +55,8 @@ Scenario: Websites validation - two invalid websites
     And I enter my "City" as "Palo Alto"
     And I select "CA" from "State"
     And I enter my "School Website" as "stafford"
+    And I select "University" from "Grade Level"
+    And I select "Public" from "School Type"
     And I press "Submit"
     Then The "#new_teacher" form is invalid
     And  I am on the BJC home page
@@ -66,6 +72,8 @@ Scenario: Websites validation - one invalid website
     And I enter my "City" as "Palo Alto"
     And I select "CA" from "State"
     And I enter my "School Website" as "stafford"
+    And I select "University" from "Grade Level"
+    And I select "Public" from "School Type"
     And I press "Submit"
     Then The "#new_teacher" form is invalid
     And  I am on the BJC home page
@@ -81,6 +89,8 @@ Scenario: Websites validation - one valid website
     And I enter my "City" as "Palo Alto"
     And I select "CA" from "State"
     And I enter my "School Website" as "https://stafford.edu"
+    And I select "University" from "Grade Level"
+    And I select "Public" from "School Type"
     And I press "Submit"
     Then I see a confirmation "Thanks for signing up for BJC"
 
@@ -98,6 +108,8 @@ Scenario: Filling out new form with existing email should not update information
     And I enter my "City" as "Cupertino"
     And I select "CA" from "State"
     And I enter my "School Website" as "https://chs.fuhsd.org"
+    And I select "University" from "Grade Level"
+    And I select "Public" from "School Type"
     And I press "Submit"
     Then I should see "Email address or Snap username already in use."
     Then the "first_name" of the user with email "alice@berkeley.edu" should be "Alice"
@@ -117,6 +129,8 @@ Scenario: Filling out new form with existing Snap should not create new teacher
     And I enter my "City" as "Cupertino"
     And I select "CA" from "State"
     And I enter my "School Website" as "https://chs.fuhsd.org"
+    And I select "University" from "Grade Level"
+    And I select "Public" from "School Type"
     And I press "Submit"
     Then I should see "Email address or Snap username already in use."
     And "mallory@berkeley.edu" is not in the database
@@ -136,6 +150,8 @@ Scenario: Filling out form should have the correct information in a Teacher
     And I enter my "City" as "Castro Valley"
     And I select "CA" from "State"
     And I enter my "School Website" as "cvhs.cv.k12.ca.us"
+    And I select "University" from "Grade Level"
+    And I select "Public" from "School Type"
     And I press "Submit"
 
     Then the "first_name" of the user with email "bbaker@berkeley.edu" should be "Bob"
@@ -162,6 +178,8 @@ Scenario: Filling out form should have the correct information in a Teacher
     And I enter my "City" as "Castro Valley"
     And I select "CA" from "State"
     And I enter my "School Website" as "cvhs.cv.k12.ca.us"
+    And I select "University" from "Grade Level"
+    And I select "Public" from "School Type"
     And I press "Submit"
 
     Then the "first_name" of the user with email "bbaker@berkeley.edu" should be "Bob"

--- a/features/school_form_submission.feature
+++ b/features/school_form_submission.feature
@@ -40,6 +40,9 @@ Scenario: Admins can create new schools
     And I fill in "City" with "Berkeley"
     And I select "CA" from "State"
     And I fill in "School Website" with "https://www.berkeley.edu/"
+    And I select "University" from "Grade Level"
+    And I select "Public" from "School Type"
+    And I fill in "NCES ID" with "012345678910"
     And I press "Submit"
     Then I should see "Created New UC Berkeley successfully"
     And I should see "New UC Berkeley" with "0" in a table row

--- a/features/school_form_submission.feature
+++ b/features/school_form_submission.feature
@@ -27,6 +27,18 @@ Scenario: Viewing the schools page should show the all current schools
     And I should see "UC Irvine" with "1" in a table row
     And I should see "UC Scam Diego" with "0" in a table row
 
+Scenario: Admins can see Tags and NCES ID
+    Given the following teachers exist:
+    | first_name | last_name | admin | email                        |
+    | Joseph     | Mamoa     | true  | testadminuser@berkeley.edu   |
+    Given I am on the BJC home page
+    Given I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    When I go to the new schools page
+    Then I should see "Tags"
+    And I should see "NCES ID"
+
 Scenario: Admins can create new schools
     Given the following teachers exist:
     | first_name | last_name | admin | email                        |
@@ -42,7 +54,7 @@ Scenario: Admins can create new schools
     And I fill in "School Website" with "https://www.berkeley.edu/"
     And I select "University" from "Grade Level"
     And I select "Public" from "School Type"
-    And I fill in "NCES ID" with "012345678910"
+    And I fill in "NCES ID" with "123456789100"
     And I press "Submit"
     Then I should see "Created New UC Berkeley successfully"
     And I should see "New UC Berkeley" with "0" in a table row

--- a/features/step_definitions/teacher_steps.rb
+++ b/features/step_definitions/teacher_steps.rb
@@ -27,7 +27,11 @@ Given(/the following schools exist/) do |schools_table|
     name: "UC Berkeley",
     city: "Berkeley",
     state: "CA",
-    website: "https://www.berkeley.edu"
+    website: "https://www.berkeley.edu",
+    grade_level: "university",
+    school_type: "public",
+    tags: [],
+    nces_id: 123456789100
   }
   schools_table.symbolic_hashes.each do |school|
     schools_default.each do |key, value|

--- a/features/teacher.feature
+++ b/features/teacher.feature
@@ -234,3 +234,48 @@ Scenario: Denied teacher should not see resend button
   Then I can log in with Google
   When I go to the edit page for Jane Austin
   Then I should not see "Resend Welcome Email"
+
+Scenario: Validated teacher should not see Tags or NCES ID
+  Given the following schools exist:
+  |       name      |     city     |  state  |            website            |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  Given the following teachers exist:
+  | first_name | last_name | admin | email                     | snap | application_status |
+  | Jane       | Austin    | false | testteacher@berkeley.edu  | Jane | validated          |
+  Given I have a teacher Google email
+  Given I am on the BJC home page
+  And I follow "Log In"
+  Then I can log in with Google
+  When I go to the edit page for Jane Austin
+  Then I should not see "Tags"
+  And I should not see "NCIS ID"
+
+Scenario: Pending teacher should not see Tags or NCES ID
+  Given the following schools exist:
+  |       name      |     city     |  state  |            website            |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  Given the following teachers exist:
+  | first_name | last_name | admin | email                     | snap | application_status |
+  | Jane       | Austin    | false | testteacher@berkeley.edu  | Jane | pending          |
+  Given I have a teacher Google email
+  Given I am on the BJC home page
+  And I follow "Log In"
+  Then I can log in with Google
+  When I go to the edit page for Jane Austin
+  Then I should not see "Tags"
+  And I should not see "NCIS ID"
+
+Scenario: Denied teacher should not see Tags or NCES ID
+  Given the following schools exist:
+  |       name      |     city     |  state  |            website            |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  Given the following teachers exist:
+  | first_name | last_name | admin | email                     | snap | application_status |
+  | Jane       | Austin    | false | testteacher@berkeley.edu  | Jane | denied |
+  Given I have a teacher Google email
+  Given I am on the BJC home page
+  And I follow "Log In"
+  Then I can log in with Google
+  When I go to the edit page for Jane Austin
+  Then I should not see "Tags"
+  And I should not see "NCIS ID"

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -20,7 +20,11 @@ RSpec.describe SchoolsController, type: :controller do
                 name: @create_school_name,
                 city: "Berkeley",
                 state: "CA",
-                website: "www.berkeley.edu"
+                website: "www.berkeley.edu",
+                school_type: 0,
+                grade_level: 4,
+                tags: [],
+                nces_id: 123456789000
             }
         }
     }
@@ -36,7 +40,11 @@ RSpec.describe SchoolsController, type: :controller do
                 name: @create_school_name,
                 city: "Berkeley",
                 state: "CA",
-                website: "www.berkeley.edu"
+                website: "www.berkeley.edu",
+                school_type: 0,
+                grade_level: 4,
+                tags: [],
+                nces_id: 123456789000
             }
         }
     }
@@ -51,7 +59,11 @@ RSpec.describe SchoolsController, type: :controller do
             school: {
                 name: @create_school_name,
                 state: "CA",
-                website: "www.berkeley.edu"
+                website: "www.berkeley.edu",
+                school_type: 0,
+                grade_level: 4,
+                tags: [],
+                nces_id: 123456789000
             }
         }
     }
@@ -64,6 +76,10 @@ RSpec.describe SchoolsController, type: :controller do
                 name: @create_school_name,
                 city: "Berkeley",
                 state: "CA",
+                school_type: 0,
+                grade_level: 4,
+                tags: [],
+                nces_id: 123456789000
             }
         }
     }
@@ -75,7 +91,11 @@ RSpec.describe SchoolsController, type: :controller do
             school: {
                 city: "Berkeley",
                 state: "CA",
-                website: "www.berkeley.edu"
+                website: "www.berkeley.edu",
+                school_type: 0,
+                grade_level: 4,
+                tags: [],
+                nces_id: 123456789000
             }
         }
     }
@@ -93,24 +113,104 @@ RSpec.describe SchoolsController, type: :controller do
                 name: @create_school_name,
                 city: "Berkeley",
                 state: "DISTRESS",
-                website: "www.berkeley.edu"
+                website: "www.berkeley.edu",
+                school_type: 0,
+                grade_level: 4,
+                tags: [],
+                nces_id: 123456789000
             }
         }
     }
     expect(School.find_by(name: @create_school_name)).to be_nil
     expect(@fail_flash_alert).to match flash[:alert]
 
+    # Incorrect website format
     post :create, {
         params: {
             school: {
                 name: @create_school_name,
                 city: "Berkeley",
                 state: "CA",
-                website: "wwwberkeleyedu"
+                website: "wwwberkeleyedu",
+                school_type: 0,
+                grade_level: 4,
+                tags: [],
+                nces_id: 123456789000
             }
         }
     }
     expect(School.find_by(name: @create_school_name)).to be_nil
     expect(@fail_flash_alert).to match flash[:alert]
+
+    # Incorrect school type
+    expect { post :create, {
+            params: {
+                school: {
+                    name: @create_school_name,
+                    city: "Berkeley",
+                    state: "CA",
+                    website: "www.berkeley.edu",
+                    school_type: -1,
+                    grade_level: 4,
+                    tags: [],
+                    nces_id: 123456789000
+                }
+            }
+        }
+    }.to raise_error(ArgumentError)
+    expect(School.find_by(name: @create_school_name)).to be_nil
+
+    # Incorrect grade_level
+    expect { post :create, {
+            params: {
+                school: {
+                    name: @create_school_name,
+                    city: "Berkeley",
+                    state: "CA",
+                    website: "www.berkeley.edu",
+                    school_type: 0,
+                    grade_level: -4,
+                    tags: [],
+                    nces_id: 123456789000
+                }
+            }
+        }
+    }.to raise_error(ArgumentError)
+    expect(School.find_by(name: @create_school_name)).to be_nil
+
+    # Out of bounds nces_id
+    expect { post :create, {
+            params: {
+                school: {
+                    name: @create_school_name,
+                    city: "Berkeley",
+                    state: "CA",
+                    website: "www.berkeley.edu",
+                    school_type: 0,
+                    grade_level: -4,
+                    tags: [],
+                    nces_id: 999999999999 + 1 # max val + 1
+                }
+            }
+        }
+    }.to raise_error(ArgumentError)
+    expect(School.find_by(name: @create_school_name)).to be_nil
+
+    expect { post :create, {
+            params: {
+                school: {
+                    name: @create_school_name,
+                    city: "Berkeley",
+                    state: "CA",
+                    website: "www.berkeley.edu",
+                    school_type: 0,
+                    grade_level: -4,
+                    tags: [],
+                    nces_id: 0 - 1 # min val - 1
+                }
+            }
+        }
+    }.to raise_error(ArgumentError)
+    expect(School.find_by(name: @create_school_name)).to be_nil
   end
 end

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -10,10 +10,10 @@
 #  name                   :string
 #  num_denied_teachers    :integer          default(0)
 #  num_validated_teachers :integer          default(0)
+#  school_type            :integer
 #  state                  :string
 #  tags                   :text             default([]), is an Array
 #  teachers_count         :integer          default(0)
-#  type                   :integer
 #  website                :string
 #  created_at             :datetime
 #  updated_at             :datetime

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -17,7 +17,7 @@
 #  website                :string
 #  created_at             :datetime
 #  updated_at             :datetime
-#  nces_id                :integer
+#  nces_id                :bigint
 #
 # Indexes
 #

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -4,16 +4,20 @@
 #
 #  id                     :bigint           not null, primary key
 #  city                   :string
+#  grade_level            :integer
 #  lat                    :float
 #  lng                    :float
 #  name                   :string
 #  num_denied_teachers    :integer          default(0)
 #  num_validated_teachers :integer          default(0)
 #  state                  :string
+#  tags                   :text             default([]), is an Array
 #  teachers_count         :integer          default(0)
+#  type                   :integer
 #  website                :string
 #  created_at             :datetime
 #  updated_at             :datetime
+#  nces_id                :integer
 #
 # Indexes
 #


### PR DESCRIPTION
We should refactor how schools are represented

add a grade_level enum column. (elementary, middle school, high school, community college, university)
add a type enum column (public, private, charter, magnet, alternative, other)
add a tags column, a text array. -- hidden in UI unless admin
add a nces_id column (bigint) -- hidden in UI unless admin

https://github.com/beautyjoy/BJC-Teacher-Tracker/issues/144


Also changes the form for creating schools to include the new fields (only shows tags and nces_id input fields if admin).